### PR TITLE
Block fetches in preview mode.

### DIFF
--- a/Sources/Directory/Directory.swift
+++ b/Sources/Directory/Directory.swift
@@ -60,6 +60,7 @@ public extension ItemStorageLocation {
     typealias ErrorConsumer = (Error) -> Void
     
     func fetch(_ operation: DispatchOperation, errorHandler: ErrorConsumer? = nil) {
+        if isPreview { return }
         switch operation {
         case .sync:
             do {

--- a/Tests/DirectoryTests/DirectoryTests.swift
+++ b/Tests/DirectoryTests/DirectoryTests.swift
@@ -39,6 +39,17 @@ final class DirectoryTests: XCTestCase {
         XCTAssertTrue(property == fetched)
     }
     
+    func testDirectoryReadPreview() throws {
+        let address = "72 Heol Llinos"
+        let property = Property(id: UUID(), date: Date(), address: address, parent: folder)
+        let handler = try Directory<Property>(parent: folder, fileName: "properties.data", isPreview: true)
+        try handler.insert(property)
+        try handler.save()
+        handler.fetch(.sync)
+        let fetched = try XCTUnwrap(handler.fetchedItems.first)
+        XCTAssertTrue(property == fetched)
+    }
+    
     func testPhotosFileCreated() throws {
         let address = "72 Heol Llinos"
         let property = Property(id: UUID(), date: Date(), address: address, parent: folder)


### PR DESCRIPTION
Fixes #4 

Fetches will be overwritten with empty array, as there will be nothing on disk (saves are also blocked in preview mode).