### PR TITLE
Use stash to cache images in volatile memory for a while.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
             targets: ["Directory"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/nashysolutions/Stash.git", from: "1.0.0"),
         .package(url: "https://github.com/JohnSundell/Files", from: "4.2.0"),
     ],
     targets: [
@@ -20,7 +21,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Directory",
-            dependencies: ["Files"]
+            dependencies: ["Files", "Stash"]
         ),
         .testTarget(
             name: "DirectoryTests",

--- a/Sources/Directory/Directory.swift
+++ b/Sources/Directory/Directory.swift
@@ -1,6 +1,7 @@
 import UIKit
 import SwiftUI
 import Files
+import Stash
 
 /// Provides a folder.
 public protocol Container {

--- a/Sources/Directory/Directory.swift
+++ b/Sources/Directory/Directory.swift
@@ -192,6 +192,10 @@ public protocol Photograph: Identifiable, KangarooItem, Comparable {
 
 public extension Photograph {
     
+    private var cacheDuration: Expiry {
+        .short
+    }
+    
     var fileName: String {
         id.uuidString
     }
@@ -207,7 +211,7 @@ public extension Photograph {
         guard let data = try? file().read(), let image = UIImage(data: data) else {
             return nil
         }
-        Cache.stash(image, with: id, duration: .short)
+        Cache.stash(image, with: id, duration: cacheDuration)
         return image
     }
 
@@ -215,7 +219,7 @@ public extension Photograph {
         guard let image = UIImage(data: data), !data.isEmpty else {
             return
         }
-        Cache.stash(image, with: id, duration: .short)
+        Cache.stash(image, with: id, duration: cacheDuration)
         let file = try folder.createFileIfNeeded(withName: fileName)
         try file.write(data)
     }

--- a/Sources/Directory/Directory.swift
+++ b/Sources/Directory/Directory.swift
@@ -201,10 +201,14 @@ public extension Photograph {
     }
     
     func read() -> UIImage? {
-        if let data = try? file().read() {
-            return UIImage(data: data)
+        if let image = Cache.resource(for: id) {
+            return image
         }
-        return nil
+        guard let data = try? file().read(), let image = UIImage(data: data) else {
+            return nil
+        }
+        Cache.stash(image, with: id, duration: .short)
+        return image
     }
 
     func write(_ data: Data) throws {

--- a/Sources/Directory/Directory.swift
+++ b/Sources/Directory/Directory.swift
@@ -212,10 +212,10 @@ public extension Photograph {
     }
 
     func write(_ data: Data) throws {
-        guard !data.isEmpty else {
-            try? file().delete()
+        guard let image = UIImage(data: data), !data.isEmpty else {
             return
         }
+        Cache.stash(image, with: id, duration: .short)
         let file = try folder.createFileIfNeeded(withName: fileName)
         try file.write(data)
     }


### PR DESCRIPTION
Images will remain in memory for a [short](https://github.com/nashysolutions/Stash/blob/7cad9b1fc03bc9aab12e4a1398a218f911a449d8/Sources/Stash/Expiry.swift#L7), duration of time.

Fixes #12 